### PR TITLE
Make CheckRange constexpr (#754)

### DIFF
--- a/include/gsl/span
+++ b/include/gsl/span
@@ -544,7 +544,7 @@ public:
 #endif // _MSC_VER
 
 private:
-    static bool CheckRange(index_type idx, index_type size) noexcept
+    static constexpr bool CheckRange(index_type idx, index_type size) noexcept
     {
         // Optimization:
         //


### PR DESCRIPTION
As it says. This has been tested against GCC-7 with C++17 standard enabled.